### PR TITLE
Support For BitcoinCore RPC Provider

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,6 +13,7 @@ esplora:
   url: <host>
   batchSize: <batchSize>
 bitcoinCore:
+  protocol: <http | https>
   rpcHost: <host>
   rpcPass: <password>
   rpcUser: <username>

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,3 +12,8 @@ providerType: <providerType>
 esplora:
   url: <host>
   batchSize: <batchSize>
+bitcoinCore:
+  rpcHost: <host>
+  rpcPass: <password>
+  rpcUser: <username>
+  rpcPort: <port>

--- a/config/dev.config.yaml
+++ b/config/dev.config.yaml
@@ -13,6 +13,7 @@ esplora:
   url: https://blockstream.info
   batchSize: 5
 bitcoinCore:
+  protocol: http
   rpcHost: 127.0.0.1
   rpcPass: polarpass
   rpcUser: polaruser

--- a/config/dev.config.yaml
+++ b/config/dev.config.yaml
@@ -7,8 +7,13 @@ db:
   synchronize: true
 app:
   port: 3000
-  network: main
+  network: regtest
 providerType: ESPLORA
 esplora:
   url: https://blockstream.info
   batchSize: 5
+bitcoinCore:
+  rpcHost: 127.0.0.1
+  rpcPass: polarpass
+  rpcUser: polaruser
+  rpcPort: 18445

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.3.7",
         "@nestjs/platform-socket.io": "^10.3.7",
-        "@nestjs/schedule": "3.0.0",
+        "@nestjs/schedule": "^3.0.0",
         "@nestjs/swagger": "^7.3.1",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.3.7",
         "axios": "^1.7.2",
-        "bitcoin-core": "^4.2.0",
+        "currency.js": "^2.0.4",
         "js-yaml": "^4.1.0",
         "pg": "^8.11.5",
         "reflect-metadata": "^0.1.13",
@@ -770,7 +770,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -782,7 +782,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1392,7 +1392,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1420,7 +1420,7 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1987,25 +1987,25 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2304,7 +2304,7 @@
       "version": "13.11.9",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -2515,29 +2515,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/@uphold/request-logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@uphold/request-logger/-/request-logger-2.0.0.tgz",
-      "integrity": "sha512-UvGS+v87C7VTtQDcFHDLfvfl1zaZaLSwSmAnV35Ne7CzAVvotmZqt9lAIoNpMpaoRpdjVIcnUDwPSeIeA//EoQ==",
-      "dependencies": {
-        "uuid": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "request": ">=2.27.0"
-      }
-    },
-    "node_modules/@uphold/request-logger/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -2712,7 +2689,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2742,7 +2719,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2873,7 +2850,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3014,22 +2991,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3049,19 +3010,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
     },
     "node_modules/axios": {
       "version": "1.7.4",
@@ -3221,22 +3169,6 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3247,31 +3179,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bitcoin-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/bitcoin-core/-/bitcoin-core-4.2.0.tgz",
-      "integrity": "sha512-QFmer//rZhyuYm0mBOVAmMhIG/EFmXDahC3a1LvNTwM8/KszxUGEAjvAT4tzm1FaDj4c7pQWMG/vOWtoKjeR3Q==",
-      "dependencies": {
-        "@uphold/request-logger": "^2.0.0",
-        "debugnyan": "^1.0.0",
-        "json-bigint": "^1.0.0",
-        "lodash": "^4.0.0",
-        "request": "^2.53.0",
-        "semver": "^5.1.0",
-        "standard-error": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=7"
-      }
-    },
-    "node_modules/bitcoin-core/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/bl": {
@@ -3344,7 +3251,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3449,23 +3356,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "engines": [
-        "node >=0.10.0"
-      ],
-      "bin": {
-        "bunyan": "bin/bunyan"
-      },
-      "optionalDependencies": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3540,11 +3430,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3637,13 +3522,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
       "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
@@ -3912,7 +3797,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -4035,7 +3920,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cron": {
       "version": "2.3.1",
@@ -4058,15 +3943,12 @@
         "node": ">= 8"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
+    "node_modules/currency.js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/currency.js/-/currency.js-2.0.4.tgz",
+      "integrity": "sha512-6/OplJYgJ0RUlli74d93HJ/OsKVBi8lB1+Z6eJYS1YZzBuIp4qKKHpJ7ad+GvTlWmLR/hLJOWTykN5Nm8NJ7+w==",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=4"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4140,31 +4022,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debugnyan": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/debugnyan/-/debugnyan-1.0.0.tgz",
-      "integrity": "sha512-dTvKxcLZCammDLFYi31NRVr5g6vjJ33uf1wcdbIPPxPxxnJ9/xj00Mh/YQkhFMw/VGavaG5KpjSC+4o9r/JjRg==",
-      "dependencies": {
-        "bunyan": "^1.8.1",
-        "debug": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/debugnyan/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/debugnyan/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/dedent": {
       "version": "1.5.1",
@@ -4288,7 +4145,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4345,32 +4202,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5195,11 +5030,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5214,18 +5044,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -5252,7 +5075,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5464,14 +5288,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
@@ -5706,14 +5522,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5824,47 +5632,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -5999,20 +5766,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -6124,7 +5877,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6488,11 +6241,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -6526,11 +6274,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -7223,11 +6966,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -7238,14 +6976,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -7260,11 +6990,6 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -7276,11 +7001,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7310,20 +7030,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7370,7 +7076,7 @@
       "version": "1.10.61",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.61.tgz",
       "integrity": "sha512-TsQsyzDttDvvzWNkbp/i0fVbzTGJIG0mUu/uNalIaRQEYeJxVQ/FPg+EJgSqfSXezREjM0V3RZ8cLVsKYhhw0Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.2",
@@ -7999,7 +7705,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8136,7 +7842,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8172,15 +7878,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8209,50 +7906,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
-    "node_modules/mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "optional": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -8262,12 +7915,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
-      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8280,15 +7927,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "optional": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -8384,14 +8022,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -8509,7 +8139,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8729,7 +8359,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8792,6 +8422,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
+      "peer": true
     },
     "node_modules/pg": {
       "version": "8.11.5",
@@ -9127,11 +8763,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9146,6 +8777,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9301,67 +8933,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9617,12 +9188,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "optional": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -10048,30 +9613,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10092,11 +9633,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/standard-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/standard-error/-/standard-error-1.1.0.tgz",
-      "integrity": "sha512-4v7qzU7oLJfMI5EltUSHCaaOd65J6S4BqKRWgzMi4EYaE5fvNabPxmAPGdxpGXqrcWjhDGI/H09CIdEuUOUeXg=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -10549,18 +10085,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -10642,7 +10166,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10743,22 +10267,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -11085,7 +10593,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11171,6 +10679,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -11200,7 +10709,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -11220,7 +10729,7 @@
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
       "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -11232,24 +10741,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -11509,7 +11000,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -11604,7 +11095,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.3.7",
         "axios": "^1.7.2",
+        "bitcoin-core": "^4.2.0",
         "js-yaml": "^4.1.0",
         "pg": "^8.11.5",
         "reflect-metadata": "^0.1.13",
@@ -769,7 +770,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -781,7 +782,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1391,7 +1392,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1419,7 +1420,7 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1986,25 +1987,25 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
       "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2303,7 +2304,7 @@
       "version": "13.11.9",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -2514,6 +2515,29 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@uphold/request-logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@uphold/request-logger/-/request-logger-2.0.0.tgz",
+      "integrity": "sha512-UvGS+v87C7VTtQDcFHDLfvfl1zaZaLSwSmAnV35Ne7CzAVvotmZqt9lAIoNpMpaoRpdjVIcnUDwPSeIeA//EoQ==",
+      "dependencies": {
+        "uuid": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "request": ">=2.27.0"
+      }
+    },
+    "node_modules/@uphold/request-logger/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
@@ -2688,7 +2712,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2718,7 +2742,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2849,7 +2873,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2990,6 +3014,22 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3009,6 +3049,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
+      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
     },
     "node_modules/axios": {
       "version": "1.7.4",
@@ -3168,6 +3221,22 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3178,6 +3247,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bitcoin-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoin-core/-/bitcoin-core-4.2.0.tgz",
+      "integrity": "sha512-QFmer//rZhyuYm0mBOVAmMhIG/EFmXDahC3a1LvNTwM8/KszxUGEAjvAT4tzm1FaDj4c7pQWMG/vOWtoKjeR3Q==",
+      "dependencies": {
+        "@uphold/request-logger": "^2.0.0",
+        "debugnyan": "^1.0.0",
+        "json-bigint": "^1.0.0",
+        "lodash": "^4.0.0",
+        "request": "^2.53.0",
+        "semver": "^5.1.0",
+        "standard-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=7"
+      }
+    },
+    "node_modules/bitcoin-core/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/bl": {
@@ -3250,7 +3344,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3355,6 +3449,23 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/bunyan": {
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
+      "engines": [
+        "node >=0.10.0"
+      ],
+      "bin": {
+        "bunyan": "bin/bunyan"
+      },
+      "optionalDependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3429,6 +3540,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3521,13 +3637,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
       "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
@@ -3796,7 +3912,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -3919,7 +4035,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cron": {
       "version": "2.3.1",
@@ -3940,6 +4056,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/data-view-buffer": {
@@ -4013,6 +4140,31 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debugnyan": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/debugnyan/-/debugnyan-1.0.0.tgz",
+      "integrity": "sha512-dTvKxcLZCammDLFYi31NRVr5g6vjJ33uf1wcdbIPPxPxxnJ9/xj00Mh/YQkhFMw/VGavaG5KpjSC+4o9r/JjRg==",
+      "dependencies": {
+        "bunyan": "^1.8.1",
+        "debug": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debugnyan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/debugnyan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/dedent": {
       "version": "1.5.1",
@@ -4136,7 +4288,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4193,10 +4345,32 @@
         "node": ">=12"
       }
     },
+    "node_modules/dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5021,6 +5195,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5035,11 +5214,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -5066,8 +5252,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -5279,6 +5464,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
@@ -5513,6 +5706,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5623,6 +5824,47 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/har-validator/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -5757,6 +5999,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -5868,7 +6124,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6232,6 +6488,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -6265,6 +6526,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6957,6 +7223,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6967,6 +7238,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -6981,6 +7260,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -6992,6 +7276,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7021,6 +7310,20 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/keyv": {
@@ -7067,7 +7370,7 @@
       "version": "1.10.61",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.61.tgz",
       "integrity": "sha512-TsQsyzDttDvvzWNkbp/i0fVbzTGJIG0mUu/uNalIaRQEYeJxVQ/FPg+EJgSqfSXezREjM0V3RZ8cLVsKYhhw0Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.2",
@@ -7696,7 +7999,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7833,7 +8136,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7869,6 +8172,15 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7897,6 +8209,50 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/mv/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mv/node_modules/rimraf": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "optional": true,
+      "dependencies": {
+        "glob": "^6.0.1"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -7906,6 +8262,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7918,6 +8280,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
+      "optional": true,
+      "bin": {
+        "ncp": "bin/ncp"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -8013,6 +8384,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -8130,7 +8509,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8350,7 +8729,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8413,12 +8792,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
-      "peer": true
     },
     "node_modules/pg": {
       "version": "8.11.5",
@@ -8754,6 +9127,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -8768,7 +9146,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8924,6 +9301,67 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -9179,6 +9617,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -9604,6 +10048,30 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -9624,6 +10092,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/standard-error/-/standard-error-1.1.0.tgz",
+      "integrity": "sha512-4v7qzU7oLJfMI5EltUSHCaaOd65J6S4BqKRWgzMi4EYaE5fvNabPxmAPGdxpGXqrcWjhDGI/H09CIdEuUOUeXg=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -10076,6 +10549,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -10157,7 +10642,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10258,6 +10743,22 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10584,7 +11085,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10670,7 +11171,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -10700,7 +11200,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -10720,7 +11220,7 @@
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
       "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -10732,6 +11232,24 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -10991,7 +11509,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -11086,7 +11604,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.3.7",
     "axios": "^1.7.2",
+    "currency.js": "^2.0.4",
     "js-yaml": "^4.1.0",
     "pg": "^8.11.5",
     "reflect-metadata": "^0.1.13",

--- a/src/block-data-providers/bitcoin-core/interfaces.ts
+++ b/src/block-data-providers/bitcoin-core/interfaces.ts
@@ -1,0 +1,49 @@
+import { TransactionInput, TransactionOutput } from '@/indexer/indexer.service';
+
+export interface Block {
+    height: number;
+    hash: string;
+    tx: BlockTransaction[];
+}
+
+export interface BlockTransaction {
+    txid: string;
+    hash: string;
+    vin: Input[];
+    vout: Output[];
+}
+
+export interface Input {
+    txid: string;
+    vout: number;
+    scriptSig: {
+        hex: string;
+    };
+    txinwitness: string[];
+}
+
+export interface Output {
+    value: number;
+    n: number;
+    scriptPubKey: {
+        hex: string;
+    };
+}
+
+export type BitcoinCoreOperationState = {
+    currentBlockHeight: number;
+    indexedBlockHeight: number;
+};
+
+export type Transaction = {
+    txid: string;
+    vin: TransactionInput[];
+    vout: TransactionOutput[];
+    blockHeight: number;
+    blockHash: string;
+};
+
+export interface RPCRequestBody {
+    method: string;
+    params: (string | number | boolean)[];
+}

--- a/src/block-data-providers/bitcoin-core/provider-fixtures.ts
+++ b/src/block-data-providers/bitcoin-core/provider-fixtures.ts
@@ -520,12 +520,12 @@ export const parsedTransactions = new Map([
                 {
                     scriptPubKey:
                         '0014fed893be0f774fe69825cafd9a4d721ceaf4d635',
-                    value: 11.56096634,
+                    value: 1156096634,
                 },
                 {
                     scriptPubKey:
                         '0014e0d0621ec10bfb9ee7902f8c46562e808e464940',
-                    value: 1,
+                    value: 100000000,
                 },
             ],
             blockHeight: 7110,

--- a/src/block-data-providers/bitcoin-core/provider-fixtures.ts
+++ b/src/block-data-providers/bitcoin-core/provider-fixtures.ts
@@ -1,0 +1,536 @@
+export const bitcoinCoreConfig = {
+    rpcHost: 'dummyhost',
+    rpcPass: 'dummypass',
+    rpcPort: 'dummyport',
+    rpcUser: 'dummyuser',
+};
+
+export const blockCountToHash = new Map([
+    [3, '5e8033c92511917056519dbfd9269d912d3e9c1f82619e4f80c86e7112c1d01c'],
+]);
+
+export const blocks = new Map([
+    [
+        '5e8033c92511917056519dbfd9269d912d3e9c1f82619e4f80c86e7112c1d01c',
+        {
+            hash: '5e8033c92511917056519dbfd9269d912d3e9c1f82619e4f80c86e7112c1d01c',
+            height: 7110,
+            tx: [
+                {
+                    txid: '34bf138230289d340190ca7ecbf90175b810d50c528138e85efc115b87f0cd4c',
+                    hash: '862580f3eb902c764cf2715e152b4d3178915ddf81306ff4f9e493704afe1e9c',
+                    version: 2,
+                    size: 169,
+                    vsize: 142,
+                    weight: 568,
+                    locktime: 0,
+                    vin: [
+                        {
+                            coinbase: '02c61b00',
+                            txinwitness: [
+                                '0000000000000000000000000000000000000000000000000000000000000000',
+                            ],
+                            sequence: 4294967295,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: 0.0000688,
+                            n: 0,
+                            scriptPubKey: {
+                                asm: '0 b2d6b843999ad97c90a8f7f7db30d20459223ed4',
+                                desc: 'addr(bcrt1qktttssuentvhey9g7lmakvxjq3vjy0k5zruwed)#j437qj43',
+                                hex: '0014b2d6b843999ad97c90a8f7f7db30d20459223ed4',
+                                address:
+                                    'bcrt1qktttssuentvhey9g7lmakvxjq3vjy0k5zruwed',
+                                type: 'witness_v0_keyhash',
+                            },
+                        },
+                        {
+                            value: 0.0,
+                            n: 1,
+                            scriptPubKey: {
+                                asm: 'OP_RETURN aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e',
+                                desc: 'raw(6a24aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e)#r7yx5qat',
+                                hex: '6a24aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e',
+                                type: 'nulldata',
+                            },
+                        },
+                    ],
+                },
+                {
+                    txid: '5dfe2f917dd266a1a962c52b50b40ab9fe446f87c39d8a25a92703292222c3a5',
+                    hash: '61532ef653de85e610a7552aae5a8766143fd39c3dc9b8d70e7cf84b1348c9e2',
+                    version: 2,
+                    size: 666,
+                    vsize: 344,
+                    weight: 1374,
+                    locktime: 7109,
+                    vin: [
+                        {
+                            txid: 'b259d69a672e1de1f72617c65a7cff5e23d9da7a7374880fed7a51c738f8ce9e',
+                            vout: 0,
+                            scriptSig: {
+                                asm: '',
+                                hex: '',
+                            },
+                            txinwitness: [
+                                '3044022051f8c942399cfe1f1c042eb5b64592a371198611632883e6c18d82389e739c4b02201ecb2a5fa89c5c77f17d086092812c2e7e8ba30a8ab3334f7f01085da7d57af001',
+                                '03306cbab059279881befea7cb2bcf7add57b969dc731379dd8043223a5960aa6b',
+                            ],
+                            sequence: 4294967293,
+                        },
+                        {
+                            txid: 'be25e07424144f5e4dd7344b3f7c069df1ce8384c29ad28abde4382bf0e31297',
+                            vout: 0,
+                            scriptSig: {
+                                asm: '',
+                                hex: '',
+                            },
+                            txinwitness: [
+                                '304402206ec7bf72d98b90a91f6c3f000b3103a25241aa73e7400523a73cb575918f7d2402203219c5af051f5cea980186d59d145deced29135754692583419925cc7263c6ae01',
+                                '0289ed58be746252bbc8d17e04b397bd68fbf32ede2b0a65b020c4c0df94e88c86',
+                            ],
+                            sequence: 4294967293,
+                        },
+                        {
+                            txid: '1c2c583439c40bc88d03a12ddac783543a1d7508c05e759d4babf88811382e64',
+                            vout: 0,
+                            scriptSig: {
+                                asm: '',
+                                hex: '',
+                            },
+                            txinwitness: [
+                                '304402202eb1999ff3bbfd23c7b53c8db41f37984d3e50ca649e0cc30d2714abd9924bbc02205eff5ac2856e0d1b2940b84570f7bc744d96c952f9f4e70ba05a3f95f56c42d001',
+                                '02a7b99a5b3975242b7155722b29e36e0a16db15f92825886a90dcd99a0e324edf',
+                            ],
+                            sequence: 4294967293,
+                        },
+                        {
+                            txid: '793c71e597c6c23452b9986311aa0276c6527ecd76fa434c4e2a4e83f5814ffc',
+                            vout: 0,
+                            scriptSig: {
+                                asm: '',
+                                hex: '',
+                            },
+                            txinwitness: [
+                                '3044022036f1dc16d106c5679e308470802896692af60114ba3b8d025fdbc934f29a46b902206fa1751fcda7e095382940a331145bbf74f6f5ca316229e9cf87a51da79a6ca701',
+                                '033a06335899335a4cdc81abb4d19b604456cc9c6a8ec56afebf09b8a0ad026a3d',
+                            ],
+                            sequence: 4294967293,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: 11.56096634,
+                            n: 0,
+                            scriptPubKey: {
+                                asm: '0 fed893be0f774fe69825cafd9a4d721ceaf4d635',
+                                desc: 'addr(bcrt1qlmvf80s0wa87dxp9et7e5ntjrn40f4343wh4cg)#l6637rsn',
+                                hex: '0014fed893be0f774fe69825cafd9a4d721ceaf4d635',
+                                address:
+                                    'bcrt1qlmvf80s0wa87dxp9et7e5ntjrn40f4343wh4cg',
+                                type: 'witness_v0_keyhash',
+                            },
+                        },
+                        {
+                            value: 1.0,
+                            n: 1,
+                            scriptPubKey: {
+                                asm: '0 e0d0621ec10bfb9ee7902f8c46562e808e464940',
+                                desc: 'addr(bcrt1qurgxy8kpp0aeaeus97xyv43wsz8yvj2q7ywagm)#hpx4jtc8',
+                                hex: '0014e0d0621ec10bfb9ee7902f8c46562e808e464940',
+                                address:
+                                    'bcrt1qurgxy8kpp0aeaeus97xyv43wsz8yvj2q7ywagm',
+                                type: 'witness_v0_keyhash',
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+]);
+
+export const rawTransactions = new Map([
+    [
+        '34bf138230289d340190ca7ecbf90175b810d50c528138e85efc115b87f0cd4c',
+        {
+            txid: '34bf138230289d340190ca7ecbf90175b810d50c528138e85efc115b87f0cd4c',
+            hash: '862580f3eb902c764cf2715e152b4d3178915ddf81306ff4f9e493704afe1e9c',
+            version: 2,
+            size: 169,
+            vsize: 142,
+            weight: 568,
+            locktime: 0,
+            vin: [
+                {
+                    coinbase: '02c61b00',
+                    txinwitness: [
+                        '0000000000000000000000000000000000000000000000000000000000000000',
+                    ],
+                    sequence: 4294967295,
+                },
+            ],
+            vout: [
+                {
+                    value: 0.0000688,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 b2d6b843999ad97c90a8f7f7db30d20459223ed4',
+                        desc: 'addr(bcrt1qktttssuentvhey9g7lmakvxjq3vjy0k5zruwed)#j437qj43',
+                        hex: '0014b2d6b843999ad97c90a8f7f7db30d20459223ed4',
+                        address: 'bcrt1qktttssuentvhey9g7lmakvxjq3vjy0k5zruwed',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 0.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: 'OP_RETURN aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e',
+                        desc: 'raw(6a24aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e)#r7yx5qat',
+                        hex: '6a24aa21a9ed387c2ab8374f5b7faf82e19713f1bc22db9a631923b98c44c4f24daf93fbaf8e',
+                        type: 'nulldata',
+                    },
+                },
+            ],
+        },
+    ],
+    [
+        '5dfe2f917dd266a1a962c52b50b40ab9fe446f87c39d8a25a92703292222c3a5',
+        {
+            txid: '5dfe2f917dd266a1a962c52b50b40ab9fe446f87c39d8a25a92703292222c3a5',
+            hash: '61532ef653de85e610a7552aae5a8766143fd39c3dc9b8d70e7cf84b1348c9e2',
+            version: 2,
+            size: 666,
+            vsize: 344,
+            weight: 1374,
+            locktime: 7109,
+            vin: [
+                {
+                    txid: 'b259d69a672e1de1f72617c65a7cff5e23d9da7a7374880fed7a51c738f8ce9e',
+                    vout: 0,
+                    scriptSig: {
+                        asm: '',
+                        hex: '',
+                    },
+                    txinwitness: [
+                        '3044022051f8c942399cfe1f1c042eb5b64592a371198611632883e6c18d82389e739c4b02201ecb2a5fa89c5c77f17d086092812c2e7e8ba30a8ab3334f7f01085da7d57af001',
+                        '03306cbab059279881befea7cb2bcf7add57b969dc731379dd8043223a5960aa6b',
+                    ],
+                    sequence: 4294967293,
+                },
+                {
+                    txid: 'be25e07424144f5e4dd7344b3f7c069df1ce8384c29ad28abde4382bf0e31297',
+                    vout: 0,
+                    scriptSig: {
+                        asm: '',
+                        hex: '',
+                    },
+                    txinwitness: [
+                        '304402206ec7bf72d98b90a91f6c3f000b3103a25241aa73e7400523a73cb575918f7d2402203219c5af051f5cea980186d59d145deced29135754692583419925cc7263c6ae01',
+                        '0289ed58be746252bbc8d17e04b397bd68fbf32ede2b0a65b020c4c0df94e88c86',
+                    ],
+                    sequence: 4294967293,
+                },
+                {
+                    txid: '1c2c583439c40bc88d03a12ddac783543a1d7508c05e759d4babf88811382e64',
+                    vout: 0,
+                    scriptSig: {
+                        asm: '',
+                        hex: '',
+                    },
+                    txinwitness: [
+                        '304402202eb1999ff3bbfd23c7b53c8db41f37984d3e50ca649e0cc30d2714abd9924bbc02205eff5ac2856e0d1b2940b84570f7bc744d96c952f9f4e70ba05a3f95f56c42d001',
+                        '02a7b99a5b3975242b7155722b29e36e0a16db15f92825886a90dcd99a0e324edf',
+                    ],
+                    sequence: 4294967293,
+                },
+                {
+                    txid: '793c71e597c6c23452b9986311aa0276c6527ecd76fa434c4e2a4e83f5814ffc',
+                    vout: 0,
+                    scriptSig: {
+                        asm: '',
+                        hex: '',
+                    },
+                    txinwitness: [
+                        '3044022036f1dc16d106c5679e308470802896692af60114ba3b8d025fdbc934f29a46b902206fa1751fcda7e095382940a331145bbf74f6f5ca316229e9cf87a51da79a6ca701',
+                        '033a06335899335a4cdc81abb4d19b604456cc9c6a8ec56afebf09b8a0ad026a3d',
+                    ],
+                    sequence: 4294967293,
+                },
+            ],
+            vout: [
+                {
+                    value: 11.56096634,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 fed893be0f774fe69825cafd9a4d721ceaf4d635',
+                        desc: 'addr(bcrt1qlmvf80s0wa87dxp9et7e5ntjrn40f4343wh4cg)#l6637rsn',
+                        hex: '0014fed893be0f774fe69825cafd9a4d721ceaf4d635',
+                        address: 'bcrt1qlmvf80s0wa87dxp9et7e5ntjrn40f4343wh4cg',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 1.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: '0 e0d0621ec10bfb9ee7902f8c46562e808e464940',
+                        desc: 'addr(bcrt1qurgxy8kpp0aeaeus97xyv43wsz8yvj2q7ywagm)#hpx4jtc8',
+                        hex: '0014e0d0621ec10bfb9ee7902f8c46562e808e464940',
+                        address: 'bcrt1qurgxy8kpp0aeaeus97xyv43wsz8yvj2q7ywagm',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+            ],
+        },
+    ],
+    [
+        'b259d69a672e1de1f72617c65a7cff5e23d9da7a7374880fed7a51c738f8ce9e',
+        {
+            txid: 'b259d69a672e1de1f72617c65a7cff5e23d9da7a7374880fed7a51c738f8ce9e',
+            hash: '9faee815492dadb1443993820c4915e2ad169d203989244e3d552a03f26f9365',
+            version: 2,
+            size: 169,
+            vsize: 142,
+            weight: 568,
+            locktime: 0,
+            vin: [
+                {
+                    coinbase: '02660100',
+                    txinwitness: [
+                        '0000000000000000000000000000000000000000000000000000000000000000',
+                    ],
+                    sequence: 4294967295,
+                },
+            ],
+            vout: [
+                {
+                    value: 12.5,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 a3b1fba843829bcb81c3619c02c5cf168fd4f67e',
+                        desc: 'addr(bcrt1q5wclh2zrs2duhqwrvxwq93w0z68afan7uzv0yx)#sfeflmc5',
+                        hex: '0014a3b1fba843829bcb81c3619c02c5cf168fd4f67e',
+                        address: 'bcrt1q5wclh2zrs2duhqwrvxwq93w0z68afan7uzv0yx',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 0.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: 'OP_RETURN aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        desc: 'raw(6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9)#cav96mf3',
+                        hex: '6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        type: 'nulldata',
+                    },
+                },
+            ],
+        },
+    ],
+    [
+        '1c2c583439c40bc88d03a12ddac783543a1d7508c05e759d4babf88811382e64',
+        {
+            txid: '1c2c583439c40bc88d03a12ddac783543a1d7508c05e759d4babf88811382e64',
+            hash: '039fafb4075ddf4a556971fcc2fa84fd1b976120da6c0752dbb3ef3d5a0158f8',
+            version: 2,
+            size: 169,
+            vsize: 142,
+            weight: 568,
+            locktime: 0,
+            vin: [
+                {
+                    coinbase: '02f70700',
+                    txinwitness: [
+                        '0000000000000000000000000000000000000000000000000000000000000000',
+                    ],
+                    sequence: 4294967295,
+                },
+            ],
+            vout: [
+                {
+                    value: 0.00610351,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 c2ee20ce3d95f7f7602016fba155f95d0cb43903',
+                        desc: 'addr(bcrt1qcthzpn3ajhmlwcpqzma6z40et5xtgwgrs3ypnj)#wrvj8tww',
+                        hex: '0014c2ee20ce3d95f7f7602016fba155f95d0cb43903',
+                        address: 'bcrt1qcthzpn3ajhmlwcpqzma6z40et5xtgwgrs3ypnj',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 0.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: 'OP_RETURN aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        desc: 'raw(6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9)#cav96mf3',
+                        hex: '6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        type: 'nulldata',
+                    },
+                },
+            ],
+        },
+    ],
+    [
+        '793c71e597c6c23452b9986311aa0276c6527ecd76fa434c4e2a4e83f5814ffc',
+        {
+            txid: '793c71e597c6c23452b9986311aa0276c6527ecd76fa434c4e2a4e83f5814ffc',
+            hash: '46d86e1ae00eb92990d9cb83dbe473008d3ec1d182d8792c645d29c20ee7fcec',
+            version: 2,
+            size: 169,
+            vsize: 142,
+            weight: 568,
+            locktime: 0,
+            vin: [
+                {
+                    coinbase: '025e0600',
+                    txinwitness: [
+                        '0000000000000000000000000000000000000000000000000000000000000000',
+                    ],
+                    sequence: 4294967295,
+                },
+            ],
+            vout: [
+                {
+                    value: 0.04882812,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 befc45ec32f57c0fe72bce2c8b078b0eee2f2b67',
+                        desc: 'addr(bcrt1qhm7ytmpj747qleeteckgkputpmhz72m8rjadc4)#n4nyswj0',
+                        hex: '0014befc45ec32f57c0fe72bce2c8b078b0eee2f2b67',
+                        address: 'bcrt1qhm7ytmpj747qleeteckgkputpmhz72m8rjadc4',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 0.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: 'OP_RETURN aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        desc: 'raw(6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9)#cav96mf3',
+                        hex: '6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        type: 'nulldata',
+                    },
+                },
+            ],
+        },
+    ],
+    [
+        'be25e07424144f5e4dd7344b3f7c069df1ce8384c29ad28abde4382bf0e31297',
+        {
+            txid: 'be25e07424144f5e4dd7344b3f7c069df1ce8384c29ad28abde4382bf0e31297',
+            hash: 'd8bcf790763ca7a3666a38c5acfb0346fabb328e93e361793588171a5726ba65',
+            version: 2,
+            size: 169,
+            vsize: 142,
+            weight: 568,
+            locktime: 0,
+            vin: [
+                {
+                    coinbase: '02300800',
+                    txinwitness: [
+                        '0000000000000000000000000000000000000000000000000000000000000000',
+                    ],
+                    sequence: 4294967295,
+                },
+            ],
+            vout: [
+                {
+                    value: 0.00610351,
+                    n: 0,
+                    scriptPubKey: {
+                        asm: '0 5266deca187c876b2dde472fd7499f008aed5256',
+                        desc: 'addr(bcrt1q2fndajsc0jrkktw7guhawjvlqz9w65jk73ksde)#gjvv2dap',
+                        hex: '00145266deca187c876b2dde472fd7499f008aed5256',
+                        address: 'bcrt1q2fndajsc0jrkktw7guhawjvlqz9w65jk73ksde',
+                        type: 'witness_v0_keyhash',
+                    },
+                },
+                {
+                    value: 0.0,
+                    n: 1,
+                    scriptPubKey: {
+                        asm: 'OP_RETURN aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        desc: 'raw(6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9)#cav96mf3',
+                        hex: '6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9',
+                        type: 'nulldata',
+                    },
+                },
+            ],
+        },
+    ],
+]);
+
+export const parsedTransactions = new Map([
+    [
+        '5dfe2f917dd266a1a962c52b50b40ab9fe446f87c39d8a25a92703292222c3a5',
+        {
+            txid: '5dfe2f917dd266a1a962c52b50b40ab9fe446f87c39d8a25a92703292222c3a5',
+            vin: [
+                {
+                    txid: 'b259d69a672e1de1f72617c65a7cff5e23d9da7a7374880fed7a51c738f8ce9e',
+                    vout: 0,
+                    scriptSig: '',
+                    witness: [
+                        '3044022051f8c942399cfe1f1c042eb5b64592a371198611632883e6c18d82389e739c4b02201ecb2a5fa89c5c77f17d086092812c2e7e8ba30a8ab3334f7f01085da7d57af001',
+                        '03306cbab059279881befea7cb2bcf7add57b969dc731379dd8043223a5960aa6b',
+                    ],
+                    prevOutScript:
+                        '0014a3b1fba843829bcb81c3619c02c5cf168fd4f67e',
+                },
+                {
+                    txid: 'be25e07424144f5e4dd7344b3f7c069df1ce8384c29ad28abde4382bf0e31297',
+                    vout: 0,
+                    scriptSig: '',
+                    witness: [
+                        '304402206ec7bf72d98b90a91f6c3f000b3103a25241aa73e7400523a73cb575918f7d2402203219c5af051f5cea980186d59d145deced29135754692583419925cc7263c6ae01',
+                        '0289ed58be746252bbc8d17e04b397bd68fbf32ede2b0a65b020c4c0df94e88c86',
+                    ],
+                    prevOutScript:
+                        '00145266deca187c876b2dde472fd7499f008aed5256',
+                },
+                {
+                    txid: '1c2c583439c40bc88d03a12ddac783543a1d7508c05e759d4babf88811382e64',
+                    vout: 0,
+                    scriptSig: '',
+                    witness: [
+                        '304402202eb1999ff3bbfd23c7b53c8db41f37984d3e50ca649e0cc30d2714abd9924bbc02205eff5ac2856e0d1b2940b84570f7bc744d96c952f9f4e70ba05a3f95f56c42d001',
+                        '02a7b99a5b3975242b7155722b29e36e0a16db15f92825886a90dcd99a0e324edf',
+                    ],
+                    prevOutScript:
+                        '0014c2ee20ce3d95f7f7602016fba155f95d0cb43903',
+                },
+                {
+                    txid: '793c71e597c6c23452b9986311aa0276c6527ecd76fa434c4e2a4e83f5814ffc',
+                    vout: 0,
+                    scriptSig: '',
+                    witness: [
+                        '3044022036f1dc16d106c5679e308470802896692af60114ba3b8d025fdbc934f29a46b902206fa1751fcda7e095382940a331145bbf74f6f5ca316229e9cf87a51da79a6ca701',
+                        '033a06335899335a4cdc81abb4d19b604456cc9c6a8ec56afebf09b8a0ad026a3d',
+                    ],
+                    prevOutScript:
+                        '0014befc45ec32f57c0fe72bce2c8b078b0eee2f2b67',
+                },
+            ],
+            vout: [
+                {
+                    scriptPubKey:
+                        '0014fed893be0f774fe69825cafd9a4d721ceaf4d635',
+                    value: 11.56096634,
+                },
+                {
+                    scriptPubKey:
+                        '0014e0d0621ec10bfb9ee7902f8c46562e808e464940',
+                    value: 1,
+                },
+            ],
+            blockHeight: 7110,
+            blockHash:
+                '5e8033c92511917056519dbfd9269d912d3e9c1f82619e4f80c86e7112c1d01c',
+        },
+    ],
+]);

--- a/src/block-data-providers/bitcoin-core/provider.spec.ts
+++ b/src/block-data-providers/bitcoin-core/provider.spec.ts
@@ -12,22 +12,11 @@ import {
     rawTransactions,
 } from '@/block-data-providers/bitcoin-core/provider-fixtures';
 import { Test, TestingModule } from '@nestjs/testing';
-describe('Bitcoincore Provider', () => {
+
+describe('Bitcoin Core Provider', () => {
     let provider: BitcoinCoreProvider;
 
     beforeEach(async () => {
-        const fakeConfigService = {
-            get: (key: string) => {
-                if (key == 'bitcoinCore') {
-                    return bitcoinCoreConfig;
-                }
-                if (key == 'app.network') {
-                    return 'regtest';
-                }
-                return null;
-            },
-        };
-
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 BitcoinCoreProvider,
@@ -39,7 +28,17 @@ describe('Bitcoincore Provider', () => {
                 },
                 {
                     provide: ConfigService,
-                    useValue: fakeConfigService as unknown as ConfigService,
+                    useValue: {
+                        get: (key: string) => {
+                            if (key == 'bitcoinCore') {
+                                return bitcoinCoreConfig;
+                            }
+                            if (key == 'app.network') {
+                                return 'regtest';
+                            }
+                            return null;
+                        },
+                    },
                 },
                 {
                     provide: OperationStateService,
@@ -52,9 +51,8 @@ describe('Bitcoincore Provider', () => {
 
         provider = module.get<BitcoinCoreProvider>(BitcoinCoreProvider);
 
-        jest.spyOn(provider as any, 'getTipHeight').mockImplementation(() => {
-            return Promise.resolve(3);
-        });
+        jest.spyOn(provider as any, 'getTipHeight').mockResolvedValue(3);
+
         jest.spyOn(provider as any, 'getBlockHash').mockImplementation(
             (height: number) => {
                 return Promise.resolve(blockCountToHash.get(height));

--- a/src/block-data-providers/bitcoin-core/provider.spec.ts
+++ b/src/block-data-providers/bitcoin-core/provider.spec.ts
@@ -1,0 +1,82 @@
+import { ConfigService } from '@nestjs/config';
+import { BitcoinCoreProvider } from '@/block-data-providers/bitcoin-core/provider';
+import {
+    bitcoinCoreConfig,
+    parsedTransactions,
+} from '@/block-data-providers/bitcoin-core/provider-fixtures';
+import { IndexerService } from '@/indexer/indexer.service';
+import { OperationStateService } from '@/operation-state/operation-state.service';
+import {
+    blockCountToHash,
+    blocks,
+    rawTransactions,
+} from '@/block-data-providers/bitcoin-core/provider-fixtures';
+import { Test, TestingModule } from '@nestjs/testing';
+describe('Bitcoincore Provider', () => {
+    let provider: BitcoinCoreProvider;
+
+    beforeEach(async () => {
+        const fakeConfigService = {
+            get: (key: string) => {
+                if (key == 'bitcoinCore') {
+                    return bitcoinCoreConfig;
+                }
+                if (key == 'app.network') {
+                    return 'regtest';
+                }
+                return null;
+            },
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BitcoinCoreProvider,
+                {
+                    provide: IndexerService,
+                    useValue: {
+                        index: jest.fn(),
+                    },
+                },
+                {
+                    provide: ConfigService,
+                    useValue: fakeConfigService as unknown as ConfigService,
+                },
+                {
+                    provide: OperationStateService,
+                    useValue: {
+                        getOperationState: jest.fn(),
+                    },
+                },
+            ],
+        }).compile();
+
+        provider = module.get<BitcoinCoreProvider>(BitcoinCoreProvider);
+
+        jest.spyOn(provider as any, 'getTipHeight').mockImplementation(() => {
+            return Promise.resolve(3);
+        });
+        jest.spyOn(provider as any, 'getBlockHash').mockImplementation(
+            (height: number) => {
+                return Promise.resolve(blockCountToHash.get(height));
+            },
+        );
+        jest.spyOn(provider as any, 'getBlock').mockImplementation(
+            (hash: string) => {
+                return Promise.resolve(blocks.get(hash));
+            },
+        );
+        jest.spyOn(provider as any, 'getRawTransaction').mockImplementation(
+            (hash: string) => {
+                return Promise.resolve(rawTransactions.get(hash));
+            },
+        );
+    });
+
+    it('should process each transaction of a block appropriately', async () => {
+        const result = await provider.processBlock(3);
+        expect(result).toHaveLength(1);
+        expect(result).toEqual(
+            expect.arrayContaining([...parsedTransactions.values()]),
+        );
+    });
+});

--- a/src/block-data-providers/bitcoin-core/provider.ts
+++ b/src/block-data-providers/bitcoin-core/provider.ts
@@ -1,0 +1,237 @@
+import { ConfigService } from '@nestjs/config';
+import { BitcoinCoreConfig } from '@/configuration.model';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { BitcoinNetwork } from '@/common/enum';
+import { TAPROOT_ACTIVATION_HEIGHT } from '@/common/constants';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import {
+    IndexerService,
+    TransactionInput,
+    TransactionOutput,
+} from '@/indexer/indexer.service';
+import { OperationStateService } from '@/operation-state/operation-state.service';
+import { BaseBlockDataProvider } from '@/block-data-providers/base-block-data-provider.abstract';
+import {
+    Block,
+    BitcoinCoreOperationState,
+    BlockTransaction,
+    Transaction,
+    Output,
+    RPCRequestBody,
+    Input,
+} from '@/block-data-providers/bitcoin-core/interfaces';
+import axios from 'axios';
+
+@Injectable()
+export class BitcoinCoreProvider
+    extends BaseBlockDataProvider
+    implements OnApplicationBootstrap
+{
+    protected readonly logger = new Logger(BitcoinCoreProvider.name);
+    protected readonly operationStateKey = 'bitcoincore-operation-state';
+    private isSyncing = false;
+
+    public constructor(
+        private readonly configService: ConfigService,
+        indexerService: IndexerService,
+        operationStateService: OperationStateService,
+    ) {
+        super(indexerService, operationStateService);
+    }
+
+    async onApplicationBootstrap() {
+        const getState = await this.getState();
+        if (getState) {
+            this.logger.log(
+                `Restoring state from previous run: ${JSON.stringify(
+                    getState,
+                )}`,
+            );
+        } else {
+            this.logger.log('No previous state found. Starting from scratch.');
+            const state: BitcoinCoreOperationState = {
+                currentBlockHeight: 0,
+                indexedBlockHeight:
+                    this.configService.get<BitcoinNetwork>('app.network') ===
+                    BitcoinNetwork.MAINNET
+                        ? TAPROOT_ACTIVATION_HEIGHT - 1
+                        : 0,
+            };
+            await this.setState(state);
+        }
+    }
+
+    @Cron(CronExpression.EVERY_10_SECONDS)
+    async sync() {
+        if (this.isSyncing) return;
+        this.isSyncing = true;
+
+        const state = await this.getState();
+        if (!state) {
+            throw new Error('State not found');
+        }
+        const tipHeight = await this.getTipHeight();
+        if (tipHeight <= state.indexedBlockHeight) {
+            this.logger.debug(
+                `No new blocks found. Current tip height: ${tipHeight}`,
+            );
+            this.isSyncing = false;
+            return;
+        }
+
+        let height = state.indexedBlockHeight + 1;
+
+        for (height; height <= tipHeight; height++) {
+            const transactions = await this.processBlock(height);
+            for (const transaction of transactions) {
+                const { txid, vin, vout, blockHeight, blockHash } = transaction;
+                await this.indexTransaction(
+                    txid,
+                    vin,
+                    vout,
+                    blockHeight,
+                    blockHash,
+                );
+            }
+            state.indexedBlockHeight = height;
+            await this.setState(state);
+        }
+        this.isSyncing = false;
+    }
+
+    private async getTipHeight(): Promise<number> {
+        const body = {
+            method: 'getblockcount',
+            params: [],
+        };
+        return this.request(body);
+    }
+
+    private async getBlockHash(height: number): Promise<string> {
+        const body = {
+            method: 'getblockhash',
+            params: [height],
+        };
+        return this.request(body);
+    }
+
+    private async getBlock(hash: string, verbosity: number): Promise<Block> {
+        const body = {
+            method: 'getblock',
+            params: [hash, verbosity],
+        };
+        return this.request(body);
+    }
+
+    private async getRawTransaction(
+        txid: string,
+        isVerbose: boolean,
+    ): Promise<BlockTransaction> {
+        const body = {
+            method: 'getrawtransaction',
+            params: [txid, isVerbose],
+        };
+        return this.request(body);
+    }
+
+    public async processBlock(height: number): Promise<Transaction[]> {
+        const parsedTransactionList: Transaction[] = [];
+        const blockHash = await this.getBlockHash(height);
+        this.logger.debug(
+            `Processing block at height ${height}, hash ${blockHash}`,
+        );
+        const block = await this.getBlock(blockHash, 2);
+        const excludedCoinbaseTxns = block.tx.slice(1);
+        for (const txn of excludedCoinbaseTxns) {
+            const parsedTransaction = await this.parseTransaction(
+                txn,
+                block.hash,
+                block.height,
+            );
+            parsedTransactionList.push(parsedTransaction);
+        }
+        return parsedTransactionList;
+    }
+
+    private async parseTransaction(
+        txn: BlockTransaction,
+        blockHash: string,
+        blockHeight: number,
+    ): Promise<Transaction> {
+        const inputs: TransactionInput[] = await Promise.all(
+            txn.vin.map(this.parseTransactionInput, this),
+        );
+        const outputs: TransactionOutput[] = txn.vout.map(
+            this.parseTransactionOutput,
+            this,
+        );
+
+        return {
+            txid: txn.txid,
+            vin: inputs,
+            vout: outputs,
+            blockHeight,
+            blockHash,
+        };
+    }
+
+    private async parseTransactionInput(
+        txnInput: Input,
+    ): Promise<TransactionInput> {
+        let witness = undefined;
+        let scriptSig = '';
+        const prevTransaction = await this.getRawTransaction(
+            txnInput.txid,
+            true,
+        );
+        const vout = txnInput.vout;
+        const prevOutScript = prevTransaction.vout.find((out) => out.n == vout)
+            .scriptPubKey.hex;
+        witness = txnInput.txinwitness;
+        scriptSig = txnInput.scriptSig.hex;
+
+        return {
+            txid: txnInput.txid,
+            vout,
+            scriptSig,
+            witness,
+            prevOutScript,
+        };
+    }
+
+    private parseTransactionOutput(txnOutput: Output): TransactionOutput {
+        return {
+            scriptPubKey: txnOutput.scriptPubKey.hex,
+            value: txnOutput.value,
+        };
+    }
+
+    private async request(body: RPCRequestBody): Promise<any> {
+        const { rpcUser, rpcPass, rpcPort, rpcHost } =
+            this.configService.get<BitcoinCoreConfig>('bitcoinCore');
+        try {
+            const response = await axios.post(
+                `http://${rpcHost}:${rpcPort}/`,
+                {
+                    ...body,
+                    jsonrpc: '1.0',
+                    id: 'silent_payment_indexer',
+                },
+                {
+                    auth: {
+                        username: rpcUser,
+                        password: rpcPass,
+                    },
+                },
+            );
+            return response.data.result;
+        } catch (error) {
+            this.logger.error(
+                `Request to BitcoinCore failed!\nRequest:\n${JSON.stringify(
+                    body,
+                )}\nError:\n${error.message}`,
+            );
+            throw error;
+        }
+    }
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,3 +4,5 @@ export const NUMS_H = Buffer.from(
 );
 
 export const TAPROOT_ACTIVATION_HEIGHT = 709632;
+
+export const SATS_PER_BTC = 100_000_000;

--- a/src/configuration.model.ts
+++ b/src/configuration.model.ts
@@ -64,6 +64,24 @@ class EsploraConfig {
     batchSize: number;
 }
 
+export class BitcoinCoreConfig {
+    @IsNotEmpty()
+    @IsString()
+    rpcHost: string;
+
+    @IsNotEmpty()
+    @IsString()
+    rpcPass: string;
+
+    @IsNotEmpty()
+    @IsString()
+    rpcUser: string;
+
+    @IsNotEmpty()
+    @IsString()
+    rpcPort: string;
+}
+
 export class Config {
     @IsDefined()
     @ValidateNested()
@@ -83,4 +101,10 @@ export class Config {
     @ValidateNested()
     @Type(() => EsploraConfig)
     esplora: EsploraConfig;
+
+    @ValidateIf((o) => o.providerType === ProviderType.BITCOIN_CORE_RPC)
+    @IsDefined()
+    @ValidateNested()
+    @Type(() => BitcoinCoreConfig)
+    bitcoinCore: BitcoinCoreConfig;
 }

--- a/src/configuration.model.ts
+++ b/src/configuration.model.ts
@@ -2,6 +2,7 @@ import {
     IsBoolean,
     IsDefined,
     IsEnum,
+    IsIn,
     IsInt,
     IsNotEmpty,
     IsString,
@@ -65,6 +66,10 @@ class EsploraConfig {
 }
 
 export class BitcoinCoreConfig {
+    @IsString()
+    @IsIn(['http', 'https'])
+    protocol: string;
+
     @IsNotEmpty()
     @IsString()
     rpcHost: string;
@@ -77,9 +82,10 @@ export class BitcoinCoreConfig {
     @IsString()
     rpcUser: string;
 
-    @IsNotEmpty()
-    @IsString()
-    rpcPort: string;
+    @IsInt()
+    @Min(1)
+    @Max(65535)
+    rpcPort: number;
 }
 
 export class Config {


### PR DESCRIPTION
### Objective
The objective this change is to add support for Bitcoincore RPC Api.

### Problem 
The silent indexer relies on the consumption of external Api's in order to be fed Bitcoin Block data needed for indexing silent payments

### Changes
- Add logic to fetch block data from a **bitcoincore** rpc endoint.  
- Added Unit test for the provided logic.
- Modified  **config module** to add support for bitcoincore RPC config details.
- Modified **Block Provider module** to switch between Esplora and Bitcoincore depending on the provided config data. 


### Scope Of Change
This is a critical change because it affects the correctness of the silent-indexer.

closes #12 

