### PR TITLE
Added `batchSize` configuration option for parallelizing requests in EsploraProvider

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,3 +11,4 @@ app:
 providerType: <providerType>
 esplora:
   url: <host>
+  batchSize: <batchSize>

--- a/config/dev.config.yaml
+++ b/config/dev.config.yaml
@@ -11,3 +11,4 @@ app:
 providerType: ESPLORA
 esplora:
   url: https://blockstream.info
+  batchSize: 5

--- a/src/configuration.model.ts
+++ b/src/configuration.model.ts
@@ -57,6 +57,11 @@ class EsploraConfig {
         require_host: true,
     })
     url: string;
+
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    batchSize: number;
 }
 
 export class Config {


### PR DESCRIPTION

Added support for batch processing in EsploraProvider by introducing a batchSize configuration option. Requests in the processBlock method are now parallelized using Promise.all() when batchSize > 1, improving efficiency. An upper limit for batchSize(100) is enforced to prevent overloading. This change optimizes block processing while respecting API rate limits.