### PR TITLE
Implement rate limiting across major services

### DIFF
--- a/config/e2e.config.yaml
+++ b/config/e2e.config.yaml
@@ -16,3 +16,6 @@ bitcoinCore:
   rpcPass: password
   rpcUser: polaruser
   rpcPort: 18443
+throttler:
+  ttl: 1000
+  limit: 5

--- a/config/example.config.yaml
+++ b/config/example.config.yaml
@@ -16,3 +16,6 @@ bitcoinCore:
   rpcPass: password
   rpcUser: polaruser
   rpcPort: 18443
+throttler:
+  ttl: 1000 # 1 sec
+  limit: 5 # 5 requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/platform-ws": "^10.4.4",
         "@nestjs/schedule": "^3.0.0",
         "@nestjs/swagger": "^7.3.1",
+        "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.3.7",
         "axios": "^1.7.2",
@@ -2177,6 +2178,17 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
+      }
     },
     "node_modules/@nestjs/typeorm": {
       "version": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nestjs/platform-ws": "^10.4.4",
     "@nestjs/schedule": "^3.0.0",
     "@nestjs/swagger": "^7.3.1",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.3.7",
     "axios": "^1.7.2",


### PR DESCRIPTION
This PR introduces rate limiting to the application to enhance security and prevent abuse from excessive requests.

## Changes:
Imported ThrottlerModule into app.module.ts.
Set up a global default rate limit (5 requests per second).
Registered ThrottlerGuard globally using APP_GUARD to protect all routes by default.

## Benefits:
Protects the application against brute-force attacks.
Prevents individual users or IP addresses from overwhelming the server with too many requests.
Improves overall application stability and availability.
## Test
![image](https://github.com/user-attachments/assets/86cfbce3-5377-42af-ad7b-756b58e03e18)
![image](https://github.com/user-attachments/assets/cd6f87c5-49c5-4483-a0ac-4682cc6902e0)

