### PR TITLE
BIP-352 Activation Height

### DIFF
--- a/src/block-data-providers/bitcoin-core/provider.ts
+++ b/src/block-data-providers/bitcoin-core/provider.ts
@@ -4,7 +4,7 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { BitcoinNetwork } from '@/common/enum';
 import {
     BITCOIN_CORE_FULL_VERBOSITY_VERSION,
-    TAPROOT_ACTIVATION_HEIGHT,
+    BIP352_ACTIVATION_HEIGHT,
 } from '@/common/constants';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import {
@@ -84,7 +84,7 @@ export class BitcoinCoreProvider
             const blockHeight =
                 this.configService.get<BitcoinNetwork>('app.network') ===
                 BitcoinNetwork.MAINNET
-                    ? TAPROOT_ACTIVATION_HEIGHT - 1
+                    ? BIP352_ACTIVATION_HEIGHT - 1
                     : 0;
             const blockHash = await this.getBlockHash(blockHeight);
 

--- a/src/block-data-providers/esplora/provider.ts
+++ b/src/block-data-providers/esplora/provider.ts
@@ -10,7 +10,7 @@ import {
     EsploraOperationState,
     EsploraTransaction,
 } from '@/block-data-providers/esplora/interface';
-import { TAPROOT_ACTIVATION_HEIGHT } from '@/common/constants';
+import { BIP352_ACTIVATION_HEIGHT } from '@/common/constants';
 import { BlockStateService } from '@/block-state/block-state.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DbTransactionService } from '@/db-transaction/db-transaction.service';
@@ -83,7 +83,7 @@ export class EsploraProvider
             const blockHeight =
                 this.configService.get<BitcoinNetwork>('app.network') ===
                 BitcoinNetwork.MAINNET
-                    ? TAPROOT_ACTIVATION_HEIGHT - 1
+                    ? BIP352_ACTIVATION_HEIGHT - 1
                     : 0;
             const blockHash = await this.getBlockHash(blockHeight);
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,7 +3,7 @@ export const NUMS_H = Buffer.from(
     'hex',
 );
 
-export const TAPROOT_ACTIVATION_HEIGHT = 709632;
+export const BIP352_ACTIVATION_HEIGHT = 842579; // 8 May, 2024 - when BIP-352 was merged
 
 export const SATS_PER_BTC = 100_000_000;
 


### PR DESCRIPTION
use BIP-352 Activation Height instead of taproot.
this allows the indexer to skip blocks, that do not support silent payments, resulting in faster indexing and less redundant work.

### reference
https://www.bitaps.com/842579
https://github.com/bitcoin/bips/pull/1458
https://github.com/bitcoin/bips/pull/2047/files