### PR TITLE
fix: Windows compatibility improvements (cross-platform scripts & paths)

### DIFF
--- a/config/e2e.config.yaml
+++ b/config/e2e.config.yaml
@@ -1,5 +1,5 @@
 db:
-  path: '/tmp/silent-pay-indexer-e2e-lmdb'
+  path: './tmp/silent-pay-indexer-e2e-lmdb'
   mapSize: 1073741824 # 1 GB — small map for e2e tests
 app:
   port: 3000

--- a/config/example.config.yaml
+++ b/config/example.config.yaml
@@ -1,5 +1,5 @@
 db:
-  path: '~/.silent-pay-indexer/db/lmdb'
+  path: './data/silent-pay-indexer-lmdb'
   mapSize: 10737418240 # 10 GB — LMDB pre-configured max; grows lazily
 app:
   port: 80

--- a/e2e/file-logger.ts
+++ b/e2e/file-logger.ts
@@ -1,8 +1,9 @@
 import { LoggerService } from '@nestjs/common';
 import { createWriteStream, existsSync, mkdirSync, WriteStream } from 'fs';
+import { join } from 'path';
 
 export class FileLogger implements LoggerService {
-    private logFolderPath = `${__dirname}/.logs`;
+    private logFolderPath = join(__dirname, '.logs');
     private logFilePath: string;
     private logFileStream: WriteStream;
 
@@ -11,7 +12,7 @@ export class FileLogger implements LoggerService {
             mkdirSync(this.logFolderPath, { recursive: true });
         }
 
-        this.logFilePath = `${this.logFolderPath}/${logFile}.log`;
+        this.logFilePath = join(this.logFolderPath, `${logFile}.log`);
         this.logFileStream = createWriteStream(this.logFilePath, {
             flags: 'a',
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "bitcoinjs-lib": "^6.1.6-rc.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cross-env": "^7.0.3",
         "dockerode": "^4.0.2",
         "ecpair": "^2.1.0",
         "eslint": "^8.0.1",
@@ -5526,6 +5527,24 @@
       "integrity": "sha512-/f6gpQuxDaqXu+1kwQYSckUglPaOrHdbIlBAu0YuW8/Cdb45XwXYNUBXg3r/9Mo6n540Kn/smKcZWko5x99KrQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "NODE_ENV=dev nest start --watch",
-    "start:debug": "NODE_ENV=dev nest start --debug --watch",
-    "start:e2e": "NODE_ENV=e2e nest start",
+    "start:dev": "cross-env NODE_ENV=dev nest start --watch",
+    "start:debug": "cross-env NODE_ENV=dev nest start --debug --watch",
+    "start:e2e": "cross-env NODE_ENV=e2e nest start",
     "start:prod": "node dist/main",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write --loglevel=silent \"src/**/*.ts\"",
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": " NODE_ENV=e2e node --trace-warnings node_modules/.bin/jest --runInBand --no-cache --forceExit --config jest-e2e.config.ts"
+    "test:e2e": "cross-env NODE_ENV=e2e node --trace-warnings node_modules/.bin/jest --runInBand --no-cache --forceExit --config jest-e2e.config.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.0.1",
@@ -81,6 +81,7 @@
     "run-script-webpack-plugin": "^0.2.0",
     "source-map-support": "^0.5.20",
     "supertest": "^6.3.4",
+    "cross-env": "^7.0.3",
     "tiny-secp256k1": "^2.2.3",
     "ts-jest": "29.0.5",
     "ts-loader": "^9.2.3",
@@ -106,7 +107,7 @@
   "lint-staged": {
     "*.ts": [
       "eslint --fix",
-      "bash -c 'npm run types:check'"
+      "npm run types:check"
     ],
     "*.{ts,yaml,json}": [
       "prettier --write"


### PR DESCRIPTION
## Problem
Windows developers could not run the project out of the box:
- `NODE_ENV=...` syntax in npm scripts fails on Windows
- `lint-staged` used `bash -c` which requires git-bash
- Config paths used Unix-specific conventions (`/tmp/`, `~/`)
- File paths used hardcoded `/` separators

## Changes
- Added `cross-env` devDependency for cross-platform env variables
- Updated `start:dev`, `start:debug`, `start:e2e`, `test:e2e` to use `cross-env NODE_ENV=...`
- Removed `bash -c` wrapper from lint-staged config
- Changed e2e config DB path from `/tmp/...` to `./tmp/...`
- Changed example config DB path from `~/...` to `./data/...`
- Replaced hardcoded `/` separators with `path.join()` in file-logger.ts

## Testing
- `npm install` completes without native build errors on Windows
- All scripts work consistently on Windows, Linux, and macOS